### PR TITLE
chore: prevent accidental pushes/merges to main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Prevent direct commits on main (local safeguard)
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$branch" = "main" ]; then
+  echo "ERROR: Direct commits to 'main' are blocked. Create a branch and open a PR instead."
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Prevent pushing to main (local safeguard)
+# Reads lines of refs from stdin: <local ref> <local sha> <remote ref> <remote sha>
+while read local_ref local_sha remote_ref remote_sha
+do
+  if [ "$remote_ref" = "refs/heads/main" ]; then
+    echo "ERROR: Pushing directly to 'main' is blocked. Create a PR to merge into 'main'."
+    exit 1
+  fi
+done
+exit 0

--- a/.github/workflows/block-main-push.yml
+++ b/.github/workflows/block-main-push.yml
@@ -1,0 +1,14 @@
+name: Block direct pushes to main
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  prevent-direct-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block direct pushes to main
+        run: |
+          echo "Direct pushes to 'main' are not allowed. Open a PR against 'dev' instead." >&2
+          exit 1

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,16 @@
+Branch & release policy
+
+- `main` is reserved for released, production-ready snapshots. Do **not** push or merge directly to `main`.
+- All development work should land on `dev` via pull requests.
+
+Local safeguards
+
+- Install the repository git hooks to prevent accidental pushes/commits to `main`:
+
+  bash scripts/install-git-hooks.sh
+
+CI safeguard
+
+- A GitHub Actions workflow will fail if anything is pushed directly to `main`.
+
+If you need to perform a release (update `main`), follow the documented release procedure and coordinate with the repository owner.


### PR DESCRIPTION
Add client-side git hooks, installer script and CI safeguard to block accidental pushes/merges to `main`.  

- `.githooks/pre-commit` — blocks commits on `main` locally
- `.githooks/pre-push` — blocks pushes to `main` locally
- `scripts/install-git-hooks.sh` — installer to enable hooks
- `.github/workflows/block-main-push.yml` — CI job that fails on direct pushes to `main`
- `docs/branch-protection.md` — guidance for branch/release policy

Please review and merge into `dev`.