### PR TITLE
feat: add CPU profiling support to performance tracking

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,7 +56,8 @@ statsvy scan [OPTIONS] [TARGET]
 | `--track-performance / --no-track-performance` | | Enable/disable both I/O + memory profiling (backward-compatible alias) |
 | `--track-io / --no-track-io` | | Enable/disable I/O throughput profiling (shows `IO: X.XX MiB/s`) |
 | `--track-mem / --no-track-mem` | | Enable/disable memory profiling (shows `Memory: peak ...`) |
-| `--profile / --no-profile` | | Enable/disable both I/O + memory profiling |
+| `--track-cpu / --no-track-cpu` | | Enable/disable CPU profiling (shows process CPU time + CPU%) |
+| `--profile / --no-profile` | | Enable/disable full profiling (I/O + memory + CPU, separate scans) |
 | `--scan-timeout N` | `--timeout` | Maximum scan duration in seconds (default: 300) |
 | `--min-lines-threshold N` | `--min-lines` | Skip files with fewer lines than N |
 | `--no-deps` | | Skip dependency analysis |
@@ -86,8 +87,18 @@ statsvy scan . --track-io
 # Memory-only profiling
 statsvy scan . --track-mem
 
-# Combined profiling (single scan)
+# CPU-only profiling
+statsvy scan . --track-cpu
+
+# Combined profiling (three scans)
 statsvy scan . --profile
+
+# Legacy alias (same as --profile)
+statsvy scan . --track-performance
+
+# CPU percentage semantics
+# CPU% (single-core) = cpu_seconds / wall_seconds * 100
+# CPU% (all-cores) = CPU% (single-core) / logical_cpu_count
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,10 +74,11 @@ General application settings.
 | `show_progress` | `bool` | `true` | Show progress indicators |
 | `performance_track_mem` | `bool` | `false` | Enable memory profiling |
 | `performance_track_io` | `bool` | `false` | Enable I/O throughput profiling |
+| `performance_track_cpu` | `bool` | `false` | Enable CPU profiling |
 
 !!! note "Legacy key"
     `track_performance` is still supported for backward compatibility.
-    When set, it enables both memory and I/O profiling.
+    When set, it enables memory, I/O, and CPU profiling.
 
 ### `[tool.statsvy.scan]`
 
@@ -183,6 +184,7 @@ color = true
 show_progress = true
 performance_track_mem = false
 performance_track_io = false
+performance_track_cpu = false
 
 [tool.statsvy.scan]
 max_depth = 5

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ type:
 # Run tests
 test:
     @echo "Running tests..."
-    uv run pytest -v --cov=statsvy --cov-report=term-missing
+    uv run pytest -n auto -v --cov=statsvy --cov-report=term-missing
 
 # Run with checks
 run: check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ statsvy = "statsvy.cli:main"
 dev = [
     "pytest>=7.4.3",
     "pytest-cov>=4.1.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.1.8",
     "pre-commit>=3.6.0",
     "ty==0.0.17",

--- a/src/statsvy/config/config_loader.py
+++ b/src/statsvy/config/config_loader.py
@@ -269,14 +269,20 @@ class ConfigLoader:
         """Map legacy `core.track_performance` to new performance flags.
 
         Updates `core.performance.track_mem` and
-        `core.performance.track_io` for backward compatibility.
+        `core.performance.track_io` / `core.performance.track_cpu`
+        for backward compatibility.
         """
         perf_obj = getattr(section_obj, "performance", None)
         if perf_obj is None or not hasattr(perf_obj, "track_mem"):
             return False
 
         normalized = ConfigValueConverter.normalize_value(value, perf_obj.track_mem)
-        new_perf = replace(perf_obj, track_mem=normalized, track_io=normalized)
+        new_perf = replace(
+            perf_obj,
+            track_mem=normalized,
+            track_io=normalized,
+            track_cpu=normalized,
+        )
         # Update the statically-typed `core` section so replace() receives a
         # concrete dataclass instance (avoids type-checker complaints).
         new_section = replace(self.config.core, performance=new_perf)

--- a/src/statsvy/core/performance_tracker.py
+++ b/src/statsvy/core/performance_tracker.py
@@ -2,10 +2,13 @@
 
 This module provides a PerformanceTracker class that measures and collects
 performance metrics during scan operations. Currently tracks memory usage
-via tracemalloc; designed to be extended with additional metrics.
+via tracemalloc and optional process CPU usage via resource.getrusage.
 """
 
+import os
+import resource
 import tracemalloc
+from time import perf_counter
 
 from statsvy.data.performance_metrics import PerformanceMetrics
 
@@ -14,9 +17,8 @@ class PerformanceTracker:
     """Tracks performance metrics during scan operations.
 
     This class encapsulates all performance tracking logic, providing a clean
-    API for measuring application performance. Currently uses tracemalloc to
-    track memory usage; future extensions can add CPU time, I/O statistics,
-    cache hit rates, etc.
+    API for measuring application performance. Uses tracemalloc to track
+    memory usage and can optionally track process CPU usage.
 
     Warning:
         Memory tracking using tracemalloc can add SIGNIFICANT overhead:
@@ -34,12 +36,21 @@ class PerformanceTracker:
           profiling without external synchronization
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, track_memory: bool = True, track_cpu: bool = False) -> None:
         """Initialize the performance tracker.
+
+        Args:
+            track_memory: If True, collect peak memory via tracemalloc.
+            track_cpu: If True, collect CPU deltas and CPU percentages.
 
         Tracker is inactive until start() is called.
         """
         self._started = False
+        self._track_memory = track_memory
+        self._track_cpu = track_cpu
+        self._cpu_start_user: float | None = None
+        self._cpu_start_system: float | None = None
+        self._wall_start: float | None = None
 
     def start(self) -> None:
         """Start performance tracking.
@@ -53,7 +64,15 @@ class PerformanceTracker:
         if self._started:
             raise RuntimeError("PerformanceTracker is already running")
 
-        tracemalloc.start()
+        if self._track_memory:
+            tracemalloc.start()
+
+        if self._track_cpu:
+            usage = resource.getrusage(resource.RUSAGE_SELF)
+            self._cpu_start_user = usage.ru_utime
+            self._cpu_start_system = usage.ru_stime
+            self._wall_start = perf_counter()
+
         self._started = True
 
     def stop(self) -> PerformanceMetrics:
@@ -68,12 +87,47 @@ class PerformanceTracker:
         if not self._started:
             raise RuntimeError("PerformanceTracker has not been started")
 
-        # Get peak memory usage (in bytes)
-        _, peak_memory = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        peak_memory = 0
+        if self._track_memory:
+            _, peak_memory = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+
+        cpu_seconds: float | None = None
+        cpu_user_seconds: float | None = None
+        cpu_system_seconds: float | None = None
+        cpu_percent_single_core: float | None = None
+        cpu_percent_all_cores: float | None = None
+
+        if (
+            self._track_cpu
+            and self._cpu_start_user is not None
+            and self._cpu_start_system is not None
+            and self._wall_start is not None
+        ):
+            usage = resource.getrusage(resource.RUSAGE_SELF)
+            cpu_user_seconds = max(0.0, usage.ru_utime - self._cpu_start_user)
+            cpu_system_seconds = max(0.0, usage.ru_stime - self._cpu_start_system)
+            cpu_seconds = cpu_user_seconds + cpu_system_seconds
+            wall_seconds = max(1e-9, perf_counter() - self._wall_start)
+
+            cpu_percent_single_core = (cpu_seconds / wall_seconds) * 100
+            cpu_count = max(1, os.cpu_count() or 1)
+            cpu_percent_all_cores = cpu_percent_single_core / cpu_count
+
+            self._cpu_start_user = None
+            self._cpu_start_system = None
+            self._wall_start = None
+
         self._started = False
 
-        return PerformanceMetrics(peak_memory_bytes=peak_memory)
+        return PerformanceMetrics(
+            peak_memory_bytes=peak_memory,
+            cpu_seconds=cpu_seconds,
+            cpu_user_seconds=cpu_user_seconds,
+            cpu_system_seconds=cpu_system_seconds,
+            cpu_percent_single_core=cpu_percent_single_core,
+            cpu_percent_all_cores=cpu_percent_all_cores,
+        )
 
     def is_active(self) -> bool:
         """Check if tracker is currently active.

--- a/src/statsvy/data/config.py
+++ b/src/statsvy/data/config.py
@@ -79,7 +79,11 @@ class Config:
                 verbose=False,
                 color=True,
                 show_progress=True,
-                performance=PerformanceConfig(track_mem=False, track_io=False),
+                performance=PerformanceConfig(
+                    track_mem=False,
+                    track_io=False,
+                    track_cpu=False,
+                ),
             ),
             scan=ScanConfig(
                 follow_symlinks=False,

--- a/src/statsvy/data/performance_config.py
+++ b/src/statsvy/data/performance_config.py
@@ -9,7 +9,9 @@ class PerformanceConfig:
 
     - track_mem: measure memory (tracemalloc)
     - track_io: measure I/O throughput (MB/s)
+    - track_cpu: measure process CPU usage (without psutil)
     """
 
     track_mem: bool
     track_io: bool
+    track_cpu: bool

--- a/src/statsvy/data/performance_metrics.py
+++ b/src/statsvy/data/performance_metrics.py
@@ -1,8 +1,8 @@
 """Performance metrics collected during scan operations.
 
 This module defines immutable data structures for tracking application
-performance metrics. Currently tracks memory usage; extensible for
-additional metrics like CPU time, I/O statistics, etc.
+performance metrics. Tracks memory, I/O, and optional CPU profiling
+statistics.
 """
 
 from dataclasses import dataclass
@@ -12,16 +12,28 @@ from dataclasses import dataclass
 class PerformanceMetrics:
     """Immutable container for performance statistics during a scan.
 
-    Tracks peak memory usage during scan. Also holds optional I/O
-    statistics (bytes read and MB/s) so a single formatter can present
-    both memory and I/O results.
+    Tracks peak memory usage during scan. Also holds optional I/O and CPU
+    statistics so a single formatter can present all performance results.
 
     Attributes:
         peak_memory_bytes: Peak memory usage in bytes during the scan.
         bytes_read: Total bytes read from disk by the scanner (when measured).
         io_mb_s: Computed I/O throughput in MiB/s (2^20) when available.
+        cpu_seconds: Total process CPU time delta (user + system).
+        cpu_user_seconds: Process user CPU time delta.
+        cpu_system_seconds: Process system CPU time delta.
+        cpu_percent_single_core: CPU usage normalized to one core.
+            Formula: cpu_seconds / wall_seconds * 100.
+            Can exceed 100% when multiple cores are actively used.
+        cpu_percent_all_cores: CPU usage normalized by logical core count.
+            Formula: cpu_percent_single_core / cpu_count.
     """
 
     peak_memory_bytes: int
     bytes_read: int = 0
     io_mb_s: float | None = None
+    cpu_seconds: float | None = None
+    cpu_user_seconds: float | None = None
+    cpu_system_seconds: float | None = None
+    cpu_percent_single_core: float | None = None
+    cpu_percent_all_cores: float | None = None

--- a/tests/cli/test_help_documentation.py
+++ b/tests/cli/test_help_documentation.py
@@ -118,6 +118,7 @@ class TestHelpDocumentation:
         assert "--profile" in help_out
         assert "--track-io" in help_out
         assert "--track-mem" in help_out
+        assert "--track-cpu" in help_out
         assert "--quiet" in help_out
 
     def test_config_help_exits_zero(self, runner: CliRunner) -> None:


### PR DESCRIPTION
## Description

Adds CPU profiling support to performance tracking while keeping the modular configuration structure introduced earlier. Also includes recovery/refinement of profiling flow and related docs/tests.

## Changes

- Add CPU profiling config flag (`track_cpu`) and wire it through config loading and CLI flags.
- Extend performance tracking/formatting/models to include CPU metrics and output.
- Update scan profiling flow for I/O, memory, and CPU runs.
- Update docs for new profiling flags and behavior.
- Update tests for CLI help, profiling behavior, timeout interactions, tracker, and formatter/data models.

## Related Issues

Closes #16

## Checklist

- [ ] `just check` passes (format, lint, type, test)
- [x] Tests added/updated for new functionality
- [x] Documentation updated if needed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Validation

- `uv run pytest -q --no-cov tests/cli/test_performance_tracking.py tests/core/test_performance_tracker.py tests/data/test_performance_metrics.py tests/cli/test_scan_timeout_flag.py`
- Result: `49 passed`
