### PR TITLE
feat: list all dependencies by default in scan output

### DIFF
--- a/src/statsvy/cli_main.py
+++ b/src/statsvy/cli_main.py
@@ -49,6 +49,7 @@ class ScanKwargs(TypedDict, total=False):
         scan_timeout: Maximum scan duration in seconds.
         min_lines_threshold: Minimum number of lines for a file to be included.
         no_deps: If True, skips dependency analysis.
+        no_deps_list: If True, shows only dep counts, not individual package names.
     """
 
     dir: str | None
@@ -77,6 +78,7 @@ class ScanKwargs(TypedDict, total=False):
     scan_timeout: int | None
     min_lines_threshold: int | None
     no_deps: bool
+    no_deps_list: bool
 
 
 def _setup_scan_config(loader: ConfigLoader, **kwargs: Unpack[ScanKwargs]) -> None:
@@ -117,6 +119,9 @@ def _setup_scan_config(loader: ConfigLoader, **kwargs: Unpack[ScanKwargs]) -> No
         storage_auto_save=not no_save if no_save else None,
         display_truncate_paths=kwargs.get("truncate_paths"),
         display_show_percentages=kwargs.get("percentages"),
+        display_show_deps_list=(
+            not no_deps_list if (no_deps_list := kwargs.get("no_deps_list")) else None
+        ),
     )
 
 
@@ -342,6 +347,11 @@ def main(ctx: click.Context, config: Path | None) -> None:
     "--no-deps",
     is_flag=True,
     help="Skip dependency analysis (dependencies analyzed by default)",
+)
+@click.option(
+    "--no-deps-list",
+    is_flag=True,
+    help="Show only dependency counts, not individual package names",
 )
 @click.option("--quiet", "-q", is_flag=True, help="Suppress console output")
 @click.pass_obj

--- a/src/statsvy/core/formatter.py
+++ b/src/statsvy/core/formatter.py
@@ -72,7 +72,7 @@ class Formatter:
                 metrics, git_info=git_info
             )
         elif format_type == "json":
-            return JsonFormatter().format(metrics, git_info=git_info)
+            return JsonFormatter(display_config).format(metrics, git_info=git_info)
         elif format_type in {"markdown", "md"}:
             return MarkdownFormatter(display_config, git_config).format(
                 metrics, git_info=git_info

--- a/src/statsvy/data/config.py
+++ b/src/statsvy/data/config.py
@@ -109,6 +109,7 @@ class DisplayConfig:
 
     truncate_paths: bool
     show_percentages: bool
+    show_deps_list: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -240,6 +241,7 @@ class Config:
             display=DisplayConfig(
                 truncate_paths=True,
                 show_percentages=True,
+                show_deps_list=True,
             ),
             comparison=ComparisonConfig(
                 show_unchanged=False,

--- a/src/statsvy/data/display_config.py
+++ b/src/statsvy/data/display_config.py
@@ -9,3 +9,4 @@ class DisplayConfig:
 
     truncate_paths: bool
     show_percentages: bool
+    show_deps_list: bool = True

--- a/src/statsvy/formatters/markdown_formatter.py
+++ b/src/statsvy/formatters/markdown_formatter.py
@@ -27,6 +27,7 @@ class MarkdownFormatter:
         self._show_percentages = (
             display_config.show_percentages if display_config else True
         )
+        self._show_deps_list = display_config.show_deps_list if display_config else True
         self._show_contributors = git_config.show_contributors if git_config else True
 
     def format(self, metrics: Metrics, git_info: GitInfo | None = None) -> str:
@@ -260,5 +261,24 @@ class MarkdownFormatter:
             lines.append("\n### Conflicts\n")
             for conflict in dep_info.conflicts:
                 lines.append(f"- {conflict}")
+
+        if self._show_deps_list and dep_info.dependencies:
+            _category_label = {
+                "prod": "Production",
+                "dev": "Development",
+                "optional": "Optional",
+            }
+            _category_order = {"prod": 0, "dev": 1, "optional": 2}
+            sorted_deps = sorted(
+                dep_info.dependencies,
+                key=lambda d: (_category_order.get(d.category, 99), d.name.lower()),
+            )
+            lines.append("\n### Packages\n")
+            lines.append("| Name | Version | Category |")
+            lines.append("|------|---------|----------|")
+            for dep in sorted_deps:
+                label = _category_label.get(dep.category, dep.category.title())
+                version = dep.version or "-"
+                lines.append(f"| {dep.name} | {version} | {label} |")
 
         return "\n".join(lines)

--- a/tests/cli/test_scan_flags_and_options.py
+++ b/tests/cli/test_scan_flags_and_options.py
@@ -312,3 +312,16 @@ class TestScanFlagsAndOptions:
         # No verbose output and minimal/empty output expected
         assert result.exit_code == 0
         assert result.output.strip() == ""
+
+    def test_no_deps_list_flag_accepted(
+        self, runner: CliRunner, temp_dir: Path
+    ) -> None:
+        """Test that --no-deps-list flag is accepted without error."""
+        result = _invoke_scan(runner, temp_dir, "--no-deps-list", "--no-save")
+        assert result.exit_code == 0
+
+    def test_no_deps_list_appears_in_help(self, runner: CliRunner) -> None:
+        """Test that --no-deps-list is documented in --help output."""
+        result = runner.invoke(main, ["scan", "--help"])
+        assert result.exit_code == 0
+        assert "--no-deps-list" in result.output

--- a/tests/formatters/test_deps_list_display.py
+++ b/tests/formatters/test_deps_list_display.py
@@ -1,0 +1,261 @@
+"""Tests for dependency list display in formatters.
+
+Verifies that all three formatters (table, markdown, json) show a full
+dependency list by default and suppress it when show_deps_list=False.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from statsvy.data.config import DisplayConfig
+from statsvy.data.dependency import Dependency
+from statsvy.data.metrics import Metrics
+from statsvy.data.project_info import DependencyInfo
+from statsvy.formatters.json_formatter import JsonFormatter
+from statsvy.formatters.markdown_formatter import MarkdownFormatter
+from statsvy.formatters.table_formatter import TableFormatter
+
+
+@pytest.fixture()
+def sample_deps() -> DependencyInfo:
+    """Create a DependencyInfo with three dependencies across all categories."""
+    dependencies = (
+        Dependency(
+            name="click",
+            version=">=8.0.0",
+            category="prod",
+            source_file="pyproject.toml",
+        ),
+        Dependency(
+            name="requests",
+            version=">=2.28.0",
+            category="prod",
+            source_file="pyproject.toml",
+        ),
+        Dependency(
+            name="pytest", version=">=7.0", category="dev", source_file="pyproject.toml"
+        ),
+        Dependency(
+            name="mypy",
+            version=">=1.0",
+            category="optional",
+            source_file="pyproject.toml",
+        ),
+    )
+    return DependencyInfo(
+        dependencies=dependencies,
+        prod_count=2,
+        dev_count=1,
+        optional_count=1,
+        total_count=4,
+        sources=("pyproject.toml",),
+        conflicts=(),
+    )
+
+
+@pytest.fixture()
+def sample_metrics(sample_deps: DependencyInfo, tmp_path: Path) -> Metrics:
+    """Create a Metrics object with dependency information."""
+    return Metrics(
+        name="test_project",
+        path=tmp_path,
+        timestamp=datetime(2024, 1, 1),
+        total_files=5,
+        total_size_bytes=1024,
+        total_size_kb=1,
+        total_size_mb=0,
+        lines_by_lang={"Python": 100},
+        comment_lines_by_lang={"Python": 10},
+        blank_lines_by_lang={"Python": 5},
+        lines_by_category={},
+        comment_lines=10,
+        blank_lines=5,
+        total_lines=100,
+        dependencies=sample_deps,
+    )
+
+
+class TestTableFormatterDepsListEnabled:
+    """Table formatter shows dep list when show_deps_list=True."""
+
+    def test_dep_list_table_present(self, sample_metrics: Metrics) -> None:
+        """Dependency List table is shown when show_deps_list=True."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        result = TableFormatter(config).format(sample_metrics)
+        assert "Dependency List" in result
+
+    def test_dep_names_present(self, sample_metrics: Metrics) -> None:
+        """Individual dependency names appear in output when show_deps_list=True."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        result = TableFormatter(config).format(sample_metrics)
+        assert "click" in result
+        assert "pytest" in result
+
+    def test_default_no_display_config_shows_list(
+        self, sample_metrics: Metrics
+    ) -> None:
+        """Dep list is shown when no display config is provided (default True)."""
+        result = TableFormatter(None).format(sample_metrics)
+        assert "Dependency List" in result
+
+
+class TestTableFormatterDepsListDisabled:
+    """Table formatter hides dep list when show_deps_list=False."""
+
+    def test_dep_list_table_absent(self, sample_metrics: Metrics) -> None:
+        """Dependency List table is absent when show_deps_list=False."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=False
+        )
+        result = TableFormatter(config).format(sample_metrics)
+        assert "Dependency List" not in result
+
+    def test_summary_table_still_present(self, sample_metrics: Metrics) -> None:
+        """Summary counts table is still shown when show_deps_list=False."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=False
+        )
+        result = TableFormatter(config).format(sample_metrics)
+        assert "Dependencies" in result
+
+
+class TestTableFormatterDepsSortOrder:
+    """Prod deps appear before dev, dev before optional."""
+
+    def test_prod_before_dev(self, sample_metrics: Metrics) -> None:
+        """Production category appears before Development in the list table."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        result = TableFormatter(config).format(sample_metrics)
+        assert result.index("Production") < result.index("Development")
+
+    def test_dev_before_optional(self, sample_metrics: Metrics) -> None:
+        """Development category appears before Optional in the list table."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        result = TableFormatter(config).format(sample_metrics)
+        assert result.index("Development") < result.index("Optional")
+
+
+class TestMarkdownFormatterDepsListEnabled:
+    """Markdown formatter shows packages section when show_deps_list=True."""
+
+    def test_packages_section_present(self, sample_metrics: Metrics) -> None:
+        """Packages section heading is present when show_deps_list=True."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        result = MarkdownFormatter(config).format(sample_metrics)
+        assert "### Packages" in result
+
+    def test_dep_names_present(self, sample_metrics: Metrics) -> None:
+        """Individual dependency names appear in markdown output."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        result = MarkdownFormatter(config).format(sample_metrics)
+        assert "click" in result
+        assert "pytest" in result
+
+    def test_default_no_display_config_shows_list(
+        self, sample_metrics: Metrics
+    ) -> None:
+        """Packages section is shown when no display config is provided."""
+        result = MarkdownFormatter(None).format(sample_metrics)
+        assert "### Packages" in result
+
+
+class TestMarkdownFormatterDepsListDisabled:
+    """Markdown formatter hides packages section when show_deps_list=False."""
+
+    def test_packages_section_absent(self, sample_metrics: Metrics) -> None:
+        """Packages section is absent when show_deps_list=False."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=False
+        )
+        result = MarkdownFormatter(config).format(sample_metrics)
+        assert "### Packages" not in result
+
+    def test_summary_table_still_present(self, sample_metrics: Metrics) -> None:
+        """Summary counts table is still rendered when show_deps_list=False."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=False
+        )
+        result = MarkdownFormatter(config).format(sample_metrics)
+        assert "## Dependencies" in result
+
+
+class TestJsonFormatterDepsListEnabled:
+    """JSON formatter includes items key when show_deps_list=True."""
+
+    def test_items_key_present(self, sample_metrics: Metrics) -> None:
+        """The items key is present in dependencies dict when show_deps_list=True."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        raw = JsonFormatter(config).format(sample_metrics)
+        data = json.loads(raw)
+        assert "items" in data["dependencies"]
+
+    def test_items_contains_dep_fields(self, sample_metrics: Metrics) -> None:
+        """Each item in the list has name, version, category and source_file fields."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        raw = JsonFormatter(config).format(sample_metrics)
+        data = json.loads(raw)
+        item = data["dependencies"]["items"][0]
+        assert "name" in item
+        assert "version" in item
+        assert "category" in item
+        assert "source_file" in item
+
+    def test_all_deps_included(self, sample_metrics: Metrics) -> None:
+        """All dependencies are included in the items list."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=True
+        )
+        raw = JsonFormatter(config).format(sample_metrics)
+        data = json.loads(raw)
+        names = {d["name"] for d in data["dependencies"]["items"]}
+        assert names == {"click", "requests", "pytest", "mypy"}
+
+    def test_default_no_display_config_includes_items(
+        self, sample_metrics: Metrics
+    ) -> None:
+        """Items are included in JSON output when no display config is provided."""
+        raw = JsonFormatter(None).format(sample_metrics)
+        data = json.loads(raw)
+        assert "items" in data["dependencies"]
+
+
+class TestJsonFormatterDepsListDisabled:
+    """JSON formatter omits items key when show_deps_list=False."""
+
+    def test_items_key_absent(self, sample_metrics: Metrics) -> None:
+        """The items key is absent from dependencies dict when show_deps_list=False."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=False
+        )
+        raw = JsonFormatter(config).format(sample_metrics)
+        data = json.loads(raw)
+        assert "items" not in data["dependencies"]
+
+    def test_count_fields_still_present(self, sample_metrics: Metrics) -> None:
+        """Summary count fields are still present when show_deps_list=False."""
+        config = DisplayConfig(
+            truncate_paths=False, show_percentages=False, show_deps_list=False
+        )
+        raw = JsonFormatter(config).format(sample_metrics)
+        data = json.loads(raw)
+        assert data["dependencies"]["total_count"] == 4
+        assert data["dependencies"]["prod_count"] == 2


### PR DESCRIPTION
## Summary

- `scan` now shows a full **Dependency List** table (name, version, category) after the existing summary counts table, for all three output formats (table, markdown, JSON)
- New `--no-deps-list` flag restores the old counts-only behavior
- Fully backwards compatible: no behavior changes without the flag; JSON only gains a new opt-in `"items"` key

## Details

| Format | Default (new) | With `--no-deps-list` |
|--------|--------------|----------------------|
| table | Summary counts + "Dependency List" table | Summary counts only |
| markdown | Summary counts + `### Packages` section | Summary counts only |
| json | `dependencies` dict with `"items"` list | `dependencies` dict without `"items"` |

The setting is stored as `show_deps_list: bool = True` in `DisplayConfig`, following the existing `truncate_paths`/`show_percentages` pattern.
