### PR TITLE
feat: add HTML export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ statsvy scan . --format json
 # Markdown format
 statsvy scan . --format markdown
 
+# HTML format
+statsvy scan . --format html
+
 # Save output to a file
 statsvy scan . --format json --output stats.json
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,6 +62,7 @@ statsvy scan [OPTIONS] [TARGET]
 | `--min-lines-threshold N` | `--min-lines` | Skip files with fewer lines than N |
 | `--no-deps` | | Skip dependency analysis |
 | `--quiet` | `-q` | Suppress console output |
+| `--no-css` | | Omit embedded CSS from HTML output |
 
 **Examples:**
 
@@ -110,6 +111,18 @@ Compare metrics between two projects side by side.
 ```
 statsvy compare [OPTIONS] PROJECT1 PROJECT2
 ```
+
+**Options:**
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--format FORMAT` | `-f` | Output format: `table`, `json`, `md`, `markdown`, `html` |
+| `--output PATH` | `-o` | Save output to file |
+| `--verbose` | `-v` | Enable verbose output |
+| `--no-color` | | Disable colored output |
+| `--truncate-paths/--no-truncate-paths` | | Truncate displayed file paths |
+| `--percentages/--no-percentages` | | Show/hide percentage columns |
+| `--no-css` | | Omit embedded CSS from HTML output |
 
 **Arguments:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -37,7 +37,7 @@ statsvy scan [OPTIONS] [TARGET]
 | `--dir PATH` | | Directory to scan (alternative to positional TARGET) |
 | `--ignore PATTERN` | `-i`, `-e` | Glob patterns to ignore (repeatable). Alias: `--exclude` |
 | `--verbose` | `-v` | Enable verbose output |
-| `--format FORMAT` | `-f` | Output format: `table`, `json`, `md`, `markdown` |
+| `--format FORMAT` | `-f` | Output format: `table`, `json`, `md`, `markdown`, `html` |
 | `--output PATH` | `-o` | Save output to file |
 | `--no-color` | | Disable colored output |
 | `--no-progress` | | Disable progress bar |
@@ -122,7 +122,7 @@ statsvy compare [OPTIONS] PROJECT1 PROJECT2
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--format FORMAT` | `-f` | Output format: `table`, `json`, `md`, `markdown` |
+| `--format FORMAT` | `-f` | Output format: `table`, `json`, `md`, `markdown`, `html` |
 | `--output PATH` | `-o` | Save output to file |
 | `--verbose` | `-v` | Enable verbose output |
 | `--no-color` | | Disable colored output |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,6 +46,12 @@ Statsvy supports three output formats:
     statsvy scan . --format html
     ```
 
+You can disable the small embedded stylesheet by adding `--no-css`:
+
+    ```bash
+    statsvy scan . --format html --no-css
+    ```
+
 Save output to a file:
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,6 +40,12 @@ Statsvy supports three output formats:
     statsvy scan . --format markdown
     ```
 
+=== "HTML"
+
+    ```bash
+    statsvy scan . --format html
+    ```
+
 Save output to a file:
 
 ```bash

--- a/src/statsvy/cli/compare_handler.py
+++ b/src/statsvy/cli/compare_handler.py
@@ -37,6 +37,7 @@ class CompareHandler:
         project2_path: str,
         output_format: str | None,
         output_path: Path | None,
+        include_css: bool | None = None,
     ) -> None:
         """Execute the complete comparison workflow.
 
@@ -45,6 +46,7 @@ class CompareHandler:
             project2_path: Path to the second project directory.
             output_format: Desired output format (table, json, md).
             output_path: Path to save output, or None to print to console.
+            include_css: When ``True`` include embedded stylesheet in HTML.
 
         Raises:
             FileNotFoundError: If either project has no history.
@@ -73,6 +75,7 @@ class CompareHandler:
                 comparison,
                 output_format,
                 display_config=self.config.display,
+                include_css=include_css,
             )
         except ValueError as e:
             console.print(Text(f"Error: {e}", style="red"))

--- a/src/statsvy/cli/compare_options.py
+++ b/src/statsvy/cli/compare_options.py
@@ -23,3 +23,4 @@ class CompareOptions:
     output: Path | None
     verbose: bool
     no_color: bool
+    no_css: bool

--- a/src/statsvy/cli/scan_handler.py
+++ b/src/statsvy/cli/scan_handler.py
@@ -47,6 +47,7 @@ class ScanHandler:
         ignore_patterns: tuple[str, ...],
         output_format: str | None,
         output_path: Path | None,
+        no_css: bool = False,
     ) -> None:
         """Execute the complete scan workflow.
 
@@ -60,6 +61,7 @@ class ScanHandler:
             ignore_patterns: Glob patterns to exclude from the scan.
             output_format: Desired output format (e.g., 'table', 'json').
             output_path: Optional path for saving formatted output to file.
+            no_css: When True suppress any embedded CSS in HTML output.
 
         Raises:
             TimeoutError: If the scan or analysis exceeds the configured
@@ -105,7 +107,7 @@ class ScanHandler:
         if cpu_metrics:
             console.print(PerformanceMetricsFormatter.format_text(cpu_metrics))
 
-        formatted = self._format_metrics(metrics, output_format)
+        formatted = self._format_metrics(metrics, output_format, include_css=not no_css)
 
         if self.config.storage.auto_save:
             Storage.save(metrics, config=self.config)
@@ -485,12 +487,19 @@ class ScanHandler:
 
         return metrics
 
-    def _format_metrics(self, metrics: Metrics, output_format: str | None) -> str:
+    def _format_metrics(
+        self,
+        metrics: Metrics,
+        output_format: str | None,
+        include_css: bool | None = None,
+    ) -> str:
         """Format metrics for output.
 
         Args:
             metrics: Metrics object to format.
             output_format: Desired format type.
+            include_css: When formatting HTML, whether to embed CSS. ``None``
+                defers to the Formatter default (which is True).
 
         Returns:
             Formatted string output.
@@ -506,4 +515,5 @@ class ScanHandler:
             git_info=git_info,
             display_config=self.config.display,
             git_config=self.config.git,
+            include_css=include_css,
         )

--- a/src/statsvy/cli_main.py
+++ b/src/statsvy/cli_main.py
@@ -247,7 +247,7 @@ def main(ctx: click.Context, config: Path | None) -> None:
 @click.option(
     "--format",
     "-f",
-    type=click.Choice(["table", "json", "md", "markdown"]),
+    type=click.Choice(["table", "json", "md", "markdown", "html"]),
     help="Output format",
 )
 @click.option(
@@ -476,7 +476,7 @@ def current() -> None:
 @click.option(
     "--format",
     "-f",
-    type=click.Choice(["table", "json", "md", "markdown"]),
+    type=click.Choice(["table", "json", "md", "markdown", "html"]),
     help="Output format",
 )
 @click.option(

--- a/src/statsvy/cli_main.py
+++ b/src/statsvy/cli_main.py
@@ -79,6 +79,7 @@ class ScanKwargs(TypedDict, total=False):
     min_lines_threshold: int | None
     no_deps: bool
     no_deps_list: bool
+    no_css: bool
 
 
 def _setup_scan_config(loader: ConfigLoader, **kwargs: Unpack[ScanKwargs]) -> None:
@@ -353,6 +354,7 @@ def main(ctx: click.Context, config: Path | None) -> None:
     is_flag=True,
     help="Show only dependency counts, not individual package names",
 )
+@click.option("--no-css", is_flag=True, help="Omit embedded CSS from HTML output")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress console output")
 @click.pass_obj
 def scan(
@@ -404,6 +406,7 @@ def scan(
             ignore_patterns=kwargs.get("ignore", ()),
             output_format=kwargs.get("format"),
             output_path=kwargs.get("output"),
+            no_css=bool(kwargs.get("no_css")),
         )
     finally:
         # Restore prior console state so tests and callers are not affected.
@@ -496,6 +499,7 @@ def current() -> None:
     show_default=False,
     help="Show or hide percentage columns in output",
 )
+@click.option("--no-css", is_flag=True, help="Omit embedded CSS from HTML exports")
 @click.pass_obj
 def compare(
     loader: ConfigLoader,
@@ -507,6 +511,7 @@ def compare(
     no_color: bool,
     truncate_paths: bool | None,
     percentages: bool | None,
+    no_css: bool,
 ) -> None:
     """Compare metrics between two projects.
 
@@ -523,6 +528,7 @@ def compare(
         no_color: Disable colored output.
         truncate_paths: Whether to truncate displayed paths.
         percentages: Whether to show percentage columns.
+        no_css: When True omit the default CSS from HTML output.
     """
     _setup_compare_config(
         loader,
@@ -538,4 +544,4 @@ def compare(
     cast(_AppConsole, console).set_color_enabled(loader.config.core.color)
 
     handler = CompareHandler(loader.config)
-    handler.execute(project1, project2, format, output)
+    handler.execute(project1, project2, format, output, include_css=not no_css)

--- a/src/statsvy/core/formatter.py
+++ b/src/statsvy/core/formatter.py
@@ -1,5 +1,7 @@
 """Coordinator module for displaying metrics in various formats."""
 
+from html import escape
+
 from statsvy.data.comparison_result import ComparisonResult
 from statsvy.data.config import DisplayConfig, GitConfig
 from statsvy.data.git_info import GitInfo
@@ -21,6 +23,7 @@ class Formatter:
         git_info: GitInfo | None = None,
         display_config: DisplayConfig | None = None,
         git_config: GitConfig | None = None,
+        include_css: bool | None = None,
     ) -> str:
         """Format metrics or comparison data based on the requested format type.
 
@@ -31,6 +34,8 @@ class Formatter:
                 (ignored for comparisons).
             display_config: Display customization options for paths and percentages.
             git_config: Optional git configuration settings.
+            include_css: When ``False`` and generating HTML omit embedded style
+                block. Defaults to ``True`` when unspecified.
 
         Returns:
             str: The formatted output string.
@@ -39,10 +44,17 @@ class Formatter:
             ValueError: If the format_type is not supported.
         """
         if isinstance(data, ComparisonResult):
-            return Formatter._format_comparison(data, format_type, display_config)
+            return Formatter._format_comparison(
+                data, format_type, display_config, include_css=include_css
+            )
         else:
             return Formatter._format_metrics(
-                data, format_type, git_info, display_config, git_config
+                data,
+                format_type,
+                git_info,
+                display_config,
+                git_config,
+                include_css=include_css,
             )
 
     @staticmethod
@@ -52,6 +64,7 @@ class Formatter:
         git_info: GitInfo | None = None,
         display_config: DisplayConfig | None = None,
         git_config: GitConfig | None = None,
+        include_css: bool | None = None,
     ) -> str:
         """Format a Metrics object based on the requested format type.
 
@@ -61,6 +74,7 @@ class Formatter:
             git_info: Optional Git repository metadata.
             display_config: Display customization options for paths and percentages.
             git_config: Optional git configuration settings.
+            include_css: When ``False`` and producing HTML omit embedded stylesheet.
 
         Returns:
             str: The formatted output string.
@@ -79,9 +93,11 @@ class Formatter:
                 metrics, git_info=git_info
             )
         elif format_type == "html":
-            return HtmlFormatter(display_config, git_config).format(
-                metrics, git_info=git_info
-            )
+            # determine whether to include CSS; default to True when unset
+            css_flag = include_css if include_css is not None else True
+            return HtmlFormatter(
+                display_config, git_config, include_css=css_flag
+            ).format(metrics, git_info=git_info)
         else:
             raise ValueError(f"Unknown format type: {format_type}")
 
@@ -90,6 +106,7 @@ class Formatter:
         comparison: ComparisonResult,
         format_type: str | None = "table",
         display_config: DisplayConfig | None = None,
+        include_css: bool | None = None,
     ) -> str:
         """Format a ComparisonResult object based on the requested format type.
 
@@ -97,6 +114,7 @@ class Formatter:
             comparison: The ComparisonResult object to display.
             format_type: The format identifier (table, json, md).
             display_config: Display customization options for paths and percentages.
+            include_css: When ``False`` and producing HTML omit embedded stylesheet.
 
         Returns:
             str: The formatted output string.
@@ -110,5 +128,29 @@ class Formatter:
             return CompareFormatter().format_json(comparison)
         elif format_type in {"markdown", "md"}:
             return CompareFormatter(display_config).format_markdown(comparison)
+        elif format_type == "html":
+            # simple HTML wrapper around markdown; preserve style toggle
+
+            md = CompareFormatter(display_config).format_markdown(comparison)
+            css_flag = include_css if include_css is not None else True
+            parts: list[str] = [
+                "<!DOCTYPE html>",
+                '<html lang="en">',
+                "<head>",
+                '<meta charset="utf-8"/><title>Comparison</title>',
+            ]
+            if css_flag:
+                parts.append(
+                    "<style>"
+                    "body{font-family:Arial,Helvetica,sans-serif;margin:1em;}"
+                    "pre{white-space:pre-wrap;font-family:inherit;}"
+                    "</style>"
+                )
+            parts.append("</head>")
+            parts.append("<body>")
+            parts.append(f"<pre>{escape(md)}</pre>")
+            parts.append("</body>")
+            parts.append("</html>")
+            return "\n".join(parts)
         else:
             raise ValueError(f"Unknown format type: {format_type}")

--- a/src/statsvy/core/formatter.py
+++ b/src/statsvy/core/formatter.py
@@ -5,6 +5,7 @@ from statsvy.data.config import DisplayConfig, GitConfig
 from statsvy.data.git_info import GitInfo
 from statsvy.data.metrics import Metrics
 from statsvy.formatters.compare_formatter import CompareFormatter
+from statsvy.formatters.html_formatter import HtmlFormatter
 from statsvy.formatters.json_formatter import JsonFormatter
 from statsvy.formatters.markdown_formatter import MarkdownFormatter
 from statsvy.formatters.table_formatter import TableFormatter
@@ -75,6 +76,10 @@ class Formatter:
             return JsonFormatter(display_config).format(metrics, git_info=git_info)
         elif format_type in {"markdown", "md"}:
             return MarkdownFormatter(display_config, git_config).format(
+                metrics, git_info=git_info
+            )
+        elif format_type == "html":
+            return HtmlFormatter(display_config, git_config).format(
                 metrics, git_info=git_info
             )
         else:

--- a/src/statsvy/formatters/html_formatter.py
+++ b/src/statsvy/formatters/html_formatter.py
@@ -1,0 +1,196 @@
+"""Formatter module for simple HTML output."""
+
+from html import escape
+
+from statsvy.data.config import DisplayConfig, GitConfig
+from statsvy.data.git_info import GitInfo
+from statsvy.data.metrics import Metrics
+from statsvy.utils.formatting import format_size, truncate_path_display
+
+
+class HtmlFormatter:
+    """Formats Metrics objects as basic HTML strings.
+
+    The output is intentionally minimal: a full HTML document with no CSS or
+    external resources. Tables are used for summary, category and language
+    sections. This formatter is intended to be consumed by a browser or saved
+    to a file.
+    """
+
+    def __init__(
+        self,
+        display_config: DisplayConfig | None = None,
+        git_config: GitConfig | None = None,
+    ) -> None:
+        """Initialize formatter with display preferences.
+
+        Args:
+            display_config: Optional display configuration overrides.
+            git_config: Optional git configuration settings.
+        """
+        self._truncate_paths = (
+            display_config.truncate_paths if display_config else False
+        )
+        self._show_percentages = (
+            display_config.show_percentages if display_config else True
+        )
+        # html formatter never shows deps or contributors in MVP
+        self._show_deps_list = (
+            display_config.show_deps_list if display_config else False
+        )
+        self._show_contributors = git_config.show_contributors if git_config else True
+
+    def format(self, metrics: Metrics, git_info: GitInfo | None = None) -> str:
+        """Format metrics data as a simple HTML document.
+
+        Args:
+            metrics: The Metrics object to format.
+            git_info: Optional Git repository metadata to include.
+
+        Returns:
+            str: An HTML document representing the metrics.
+        """
+        # start document
+        title = escape(metrics.name)
+        html_parts: list[str] = [
+            "<!DOCTYPE html>",
+            '<html lang="en">',
+            "<head>",
+            f'<meta charset="utf-8"/><title>{title}</title>',
+            "</head>",
+            "<body>",
+            f"<h1>Scan: {title}</h1>",
+        ]
+
+        html_parts.append(self._format_summary(metrics, git_info))
+
+        if hasattr(metrics, "lines_by_category") and metrics.lines_by_category:
+            html_parts.append(self._format_category_table(metrics))
+
+        if metrics.lines_by_lang:
+            html_parts.append(self._format_language_table(metrics))
+
+        html_parts.append("</body>")
+        html_parts.append("</html>")
+
+        return "\n".join(html_parts)
+
+    def _format_summary(self, metrics: Metrics, git_info: GitInfo | None) -> str:
+        """Return HTML for summary information."""
+        path_value = (
+            truncate_path_display(metrics.path)
+            if self._truncate_paths
+            else str(metrics.path)
+        )
+
+        bytes_val: int | None = None
+        tsb = getattr(metrics, "total_size_bytes", None)
+        if isinstance(tsb, int | float):
+            bytes_val = int(tsb)
+        else:
+            tsk = getattr(metrics, "total_size_kb", None)
+            if isinstance(tsk, int | float):
+                bytes_val = int(tsk) * 1024
+            else:
+                tsm = getattr(metrics, "total_size_mb", None)
+                if isinstance(tsm, int | float):
+                    bytes_val = int(tsm * 1024 * 1024)
+
+        lines: list[str] = [
+            "<h2>Project Statistics</h2>",
+            "<table>",
+            "<tr><th>Field</th><th>Value</th></tr>",
+            f"<tr><td>Path</td><td>{escape(path_value)}</td></tr>",
+            f"<tr><td>Timestamp</td><td>{escape(metrics.timestamp.strftime('%Y-%m-%d'))}</td></tr>",
+            f"<tr><td>Files</td><td>{metrics.total_files:,}</td></tr>",
+            f"<tr><td>Size</td><td>{escape(format_size(bytes_val or 0))}</td></tr>",
+            f"<tr><td>Total Lines</td><td>{metrics.total_lines:,}</td></tr>",
+        ]
+
+        if git_info is not None:
+            repo_label = "Yes" if git_info.is_git_repo else "No"
+            contributors = (
+                ", ".join(git_info.contributors) if git_info.contributors else "-"
+            )
+            lines.extend(
+                [
+                    f"<tr><td>Git Repo</td><td>{repo_label}</td></tr>",
+                    (
+                        f"<tr><td>Git Branch</td><td>"
+                        f"{escape(git_info.current_branch or '-')}"
+                        "</td></tr>"
+                    ),
+                    (
+                        f"<tr><td>Git Remote</td><td>"
+                        f"{escape(git_info.remote_url or '-')}"
+                        "</td></tr>"
+                    ),
+                ]
+            )
+            if self._show_contributors:
+                lines.append(
+                    f"<tr><td>Contributors</td><td>{escape(contributors)}</td></tr>"
+                )
+            # other git info omitted for MVP
+        lines.append("</table>")
+        return "\n".join(lines)
+
+    def _format_category_table(self, metrics: Metrics) -> str:
+        """Return HTML table for lines-by-category."""
+        rows: list[str] = []
+        for category, count in sorted(
+            metrics.lines_by_category.items(), key=lambda x: x[1], reverse=True
+        ):
+            display_name = category.title() if category != "unknown" else "Unknown"
+            if self._show_percentages:
+                pct = (
+                    (count / metrics.total_lines * 100)
+                    if metrics.total_lines > 0
+                    else 0
+                )
+                rows.append(
+                    f"<tr><td>{escape(display_name)}</td><td>{count:,}</td><td>{pct:.1f}%</td></tr>"
+                )
+            else:
+                rows.append(
+                    f"<tr><td>{escape(display_name)}</td><td>{count:,}</td></tr>"
+                )
+        header = (
+            "<tr><th>Category</th><th>Lines</th><th>%</th></tr>"
+            if self._show_percentages
+            else "<tr><th>Category</th><th>Lines</th></tr>"
+        )
+        table = ["<h2>Lines of Code by Type</h2>", "<table>", header]
+        table.extend(rows)
+        table.append("</table>")
+        return "\n".join(table)
+
+    def _format_language_table(self, metrics: Metrics) -> str:
+        """Return HTML table for lines-by-language."""
+        header_cells = ["Language", "Lines"]
+        if self._show_percentages:
+            header_cells.append("%")
+        header_cells.extend(["Code", "Comments", "Blank"])
+        header = "".join(f"<th>{cell}</th>" for cell in header_cells)
+        rows: list[str] = []
+        for lang, lines_count in sorted(
+            metrics.lines_by_lang.items(), key=lambda x: x[1], reverse=True
+        ):
+            comments = metrics.comment_lines_by_lang.get(lang, 0)
+            blanks = metrics.blank_lines_by_lang.get(lang, 0)
+            code = lines_count - comments - blanks
+            cells = [escape(lang), f"{lines_count:,}"]
+            if self._show_percentages:
+                pct = (
+                    (lines_count / metrics.total_lines * 100)
+                    if metrics.total_lines > 0
+                    else 0
+                )
+                cells.append(f"{pct:.1f}%")
+            cells.extend([f"{code:,}", f"{comments:,}", f"{blanks:,}"])
+            rows.append("".join(f"<td>{c}</td>" for c in cells))
+        table = ["<h2>Lines of Code by Language</h2>", "<table>", f"<tr>{header}</tr>"]
+        for r in rows:
+            table.append(f"<tr>{r}</tr>")
+        table.append("</table>")
+        return "\n".join(table)

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -123,6 +123,43 @@ class TestCLICommands:
         assert result.exit_code == 0
         mock_show_current.assert_called_once()
 
+    @patch("statsvy.cli_main.CompareHandler.execute")
+    def test_compare_no_css_flag(
+        self, mock_execute: MagicMock, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """CLI should accept --no-css and forward the boolean to handler."""
+        # create two dummy project directories so click validation passes
+        dir1 = tmp_path / "proj1"
+        dir2 = tmp_path / "proj2"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        result = runner.invoke(
+            main,
+            ["compare", str(dir1), str(dir2), "--no-css"],
+        )
+        assert result.exit_code == 0
+        # verify handler was called and the include_css kwarg is False
+        assert mock_execute.called
+        kwargs = mock_execute.call_args[1]  # keyword args of call
+        assert kwargs.get("include_css") is False
+
+    @patch("statsvy.cli_main.CompareHandler.execute")
+    def test_compare_default_css(
+        self, mock_execute: MagicMock, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """When --no-css is omitted the handler should receive include_css=True."""
+        dir1 = tmp_path / "proj1"
+        dir2 = tmp_path / "proj2"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        result = runner.invoke(main, ["compare", str(dir1), str(dir2)])
+        assert result.exit_code == 0
+        assert mock_execute.called
+        kwargs = mock_execute.call_args[1]
+        assert kwargs.get("include_css") is True
+
     def test_config_command_exits_zero(self, runner: CliRunner) -> None:
         """Test that config command exits with code 0."""
         assert runner.invoke(main, ["config"]).exit_code == 0

--- a/tests/cli/test_compare_options.py
+++ b/tests/cli/test_compare_options.py
@@ -19,6 +19,7 @@ def test_compare_options_fields_and_immutability(tmp_path: Path) -> None:
         output=out_file,
         verbose=True,
         no_color=False,
+        no_css=False,
     )
 
     assert opts.project1 == "/repo/a"
@@ -28,6 +29,7 @@ def test_compare_options_fields_and_immutability(tmp_path: Path) -> None:
     assert isinstance(opts.output, Path)
     assert opts.verbose is True
     assert opts.no_color is False
+    assert opts.no_css is False
 
     # dataclass is frozen -> assignment should raise FrozenInstanceError
     with pytest.raises(FrozenInstanceError):

--- a/tests/cli/test_help_documentation.py
+++ b/tests/cli/test_help_documentation.py
@@ -120,7 +120,14 @@ class TestHelpDocumentation:
         assert "--track-mem" in help_out
         assert "--track-cpu" in help_out
         assert "--quiet" in help_out
+        # newly added CSS toggle
+        assert "--no-css" in help_out
 
     def test_config_help_exits_zero(self, runner: CliRunner) -> None:
         """Test that config --help exits with code 0."""
         assert runner.invoke(main, ["config", "--help"]).exit_code == 0
+
+    def test_compare_help_mentions_no_css(self, runner: CliRunner) -> None:
+        """Compare help should document the --no-css option."""
+        help_out = runner.invoke(main, ["compare", "--help"]).output.lower()
+        assert "--no-css" in help_out

--- a/tests/cli/test_scan_flags_and_options.py
+++ b/tests/cli/test_scan_flags_and_options.py
@@ -227,6 +227,18 @@ class TestScanFlagsAndOptions:
         result = _invoke_scan(runner, temp_dir, "--format", "html")
         assert result.exit_code == 0
 
+    def test_default_html_includes_css(self, runner: CliRunner, temp_dir: Path) -> None:
+        """When generating HTML without flags the output should contain CSS."""
+        result = _invoke_scan(runner, temp_dir, "--format", "html")
+        assert result.exit_code == 0
+        assert "<style" in result.output
+
+    def test_no_css_flag_omits_style(self, runner: CliRunner, temp_dir: Path) -> None:
+        """The --no-css flag should prevent the stylesheet from appearing."""
+        result = _invoke_scan(runner, temp_dir, "--format", "html", "--no-css")
+        assert result.exit_code == 0
+        assert "<style" not in result.output
+
     def test_output_file_option_saves_file(
         self, runner: CliRunner, temp_dir: Path, tmp_path: Path
     ) -> None:

--- a/tests/cli/test_scan_flags_and_options.py
+++ b/tests/cli/test_scan_flags_and_options.py
@@ -222,6 +222,11 @@ class TestScanFlagsAndOptions:
         result = _invoke_scan(runner, temp_dir, "--format", "markdown")
         assert result.exit_code == 0
 
+    def test_format_html_accepted(self, runner: CliRunner, temp_dir: Path) -> None:
+        """Test that --format html is accepted."""
+        result = _invoke_scan(runner, temp_dir, "--format", "html")
+        assert result.exit_code == 0
+
     def test_output_file_option_saves_file(
         self, runner: CliRunner, temp_dir: Path, tmp_path: Path
     ) -> None:

--- a/tests/formatter/test_formatter.py
+++ b/tests/formatter/test_formatter.py
@@ -36,6 +36,11 @@ class TestFormatter:
         result = Formatter.format(minimal_metrics, format_type="markdown")
         assert "# Scan:" in result
 
+    def test_html_format_type(self, minimal_metrics: MagicMock) -> None:
+        """format_type='html' must return a basic HTML document."""
+        result = Formatter.format(minimal_metrics, format_type="html")
+        assert "<html" in result and "<table" in result
+
     def test_unknown_format_type_raises(self, minimal_metrics: MagicMock) -> None:
         """An unknown format_type must raise ValueError."""
         with pytest.raises(ValueError, match="Unknown format type: xml"):

--- a/tests/formatters/test_compare_display_customization.py
+++ b/tests/formatters/test_compare_display_customization.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from statsvy.core.comparison import ComparisonAnalyzer
+from statsvy.core.formatter import Formatter
 from statsvy.data.config import DisplayConfig
 from statsvy.data.metrics import Metrics
 from statsvy.formatters.compare_formatter import CompareFormatter
@@ -127,3 +128,32 @@ class TestCompareFormatterPercentages:
 
         # Default should show percentages
         assert "%" in result
+
+    # HTML-specific tests using the central Formatter to exercise include_css
+    def test_comparison_html_includes_css(
+        self, project1_metrics: Metrics, project2_metrics: Metrics
+    ) -> None:
+        """When HTML is requested without disabling CSS a <style> tag appears."""
+        comparison = ComparisonAnalyzer.compare(project1_metrics, project2_metrics)
+        html = Formatter.format(
+            comparison,
+            "html",
+            display_config=DisplayConfig(truncate_paths=False, show_percentages=True),
+            include_css=True,
+        )
+        assert html.strip().startswith("<!DOCTYPE html>")
+        assert "<style" in html
+
+    def test_comparison_html_no_css(
+        self, project1_metrics: Metrics, project2_metrics: Metrics
+    ) -> None:
+        """Setting include_css=False should omit any <style> block."""
+        comparison = ComparisonAnalyzer.compare(project1_metrics, project2_metrics)
+        html = Formatter.format(
+            comparison,
+            "html",
+            display_config=DisplayConfig(truncate_paths=False, show_percentages=True),
+            include_css=False,
+        )
+        assert html.strip().startswith("<!DOCTYPE html>")
+        assert "<style" not in html

--- a/tests/formatters/test_html_formatter.py
+++ b/tests/formatters/test_html_formatter.py
@@ -3,6 +3,8 @@
 from html import escape
 from unittest.mock import MagicMock
 
+from statsvy.data.dependency import Dependency
+from statsvy.data.project_info import DependencyInfo
 from statsvy.formatters.html_formatter import HtmlFormatter
 
 
@@ -39,3 +41,21 @@ class TestHtmlFormatter:
         result = fmt.format(minimal_metrics)
         assert "<proj>" not in result
         assert escape(minimal_metrics.name) in result
+
+    def test_dependencies_section(self, minimal_metrics: MagicMock) -> None:
+        """Dependencies are included by default with package listing."""
+        dep = Dependency(name="foo", version="1.0", category="prod", source_file="p1")
+        minimal_metrics.dependencies = DependencyInfo(
+            dependencies=(dep,),
+            prod_count=1,
+            dev_count=0,
+            optional_count=0,
+            total_count=1,
+            sources=("p1",),
+            conflicts=(),
+        )
+
+        fmt = HtmlFormatter()
+        result = fmt.format(minimal_metrics)
+        assert "<h2>Dependencies</h2>" in result
+        assert "foo" in result

--- a/tests/formatters/test_html_formatter.py
+++ b/tests/formatters/test_html_formatter.py
@@ -59,3 +59,16 @@ class TestHtmlFormatter:
         result = fmt.format(minimal_metrics)
         assert "<h2>Dependencies</h2>" in result
         assert "foo" in result
+
+    def test_default_includes_css(self, minimal_metrics: MagicMock) -> None:
+        """By default the formatter should insert a <style> block."""
+        fmt = HtmlFormatter()
+        output = fmt.format(minimal_metrics)
+        assert "<style" in output
+        assert "table" in output  # some CSS rules present
+
+    def test_disable_css(self, minimal_metrics: MagicMock) -> None:
+        """When include_css=False the style block must be omitted."""
+        fmt = HtmlFormatter(include_css=False)
+        output = fmt.format(minimal_metrics)
+        assert "<style" not in output

--- a/tests/formatters/test_html_formatter.py
+++ b/tests/formatters/test_html_formatter.py
@@ -1,0 +1,41 @@
+"""Unit tests for the HtmlFormatter class."""
+
+from html import escape
+from unittest.mock import MagicMock
+
+from statsvy.formatters.html_formatter import HtmlFormatter
+
+
+class TestHtmlFormatter:
+    """Tests verifying basic HTML output structure."""
+
+    def test_basic_structure(self, minimal_metrics: MagicMock) -> None:
+        """Output should be a complete HTML document with head and body."""
+        fmt = HtmlFormatter()
+        result = fmt.format(minimal_metrics)
+        assert result.strip().startswith("<!DOCTYPE html>")
+        assert "<html" in result and "</html>" in result
+        assert "<body>" in result and "</body>" in result
+
+    def test_summary_table(self, minimal_metrics: MagicMock) -> None:
+        """Summary section should include project name and total lines."""
+        fmt = HtmlFormatter()
+        result = fmt.format(minimal_metrics)
+        assert "<h2>Project Statistics</h2>" in result
+        assert "Total Lines" in result
+        assert escape(minimal_metrics.name) in result
+
+    def test_category_and_language_tables(self, full_metrics: MagicMock) -> None:
+        """When metrics contain category/lang data, tables are rendered."""
+        fmt = HtmlFormatter()
+        result = fmt.format(full_metrics)
+        assert "Lines of Code by Type" in result
+        assert "Lines of Code by Language" in result
+
+    def test_escaping(self, minimal_metrics: MagicMock) -> None:
+        """Special characters in names/paths should be escaped."""
+        minimal_metrics.name = "<proj>&"  # some chars needing escape
+        fmt = HtmlFormatter()
+        result = fmt.format(minimal_metrics)
+        assert "<proj>" not in result
+        assert escape(minimal_metrics.name) in result


### PR DESCRIPTION
## Summary
- add HTML formatter support and wire `--format html` into scan output
- add HTML-specific formatter tests and CLI coverage for HTML output behavior
- update docs for HTML usage and output options

## Scope
This PR is intended to include only html-export related changes on `feat/html-export`.