### PR TITLE
feat: add class-based public API and developer docs

### DIFF
--- a/docs/developer-api.md
+++ b/docs/developer-api.md
@@ -1,0 +1,86 @@
+# Developer API
+
+This guide is for developers integrating Statsvy as a Python library instead of using the CLI.
+
+## Audience and Scope
+
+Use the Developer API when you want to:
+
+- run scans from Python code,
+- compare scan snapshots programmatically,
+- produce formatted output for your own pipelines.
+
+The public entrypoint is the `StatsvyApi` class in `statsvy.api`.
+
+## Stability Contract
+
+Statsvy maintains API compatibility by exposing a narrow surface and stable DTOs:
+
+- `StatsvyApi`
+- `ApiScanResult`
+- `ApiComparisonResult`
+
+Compatibility follows the package versioning strategy. The API contract is validated by dedicated tests in `tests/api/`.
+
+## Quick Start
+
+```python
+from statsvy.api import StatsvyApi
+
+backend = StatsvyApi.scan("services/backend")
+frontend = StatsvyApi.scan("services/frontend")
+comparison = StatsvyApi.compare(backend, frontend)
+
+json_output = StatsvyApi.format_result(comparison, output_format="json")
+print(json_output)
+```
+
+## API Reference
+
+### `StatsvyApi.scan(path, config=None) -> ApiScanResult`
+
+Scans and analyzes a project directory.
+
+- Delegates scanning to internal scanner modules.
+- Delegates line/language analysis to internal analyzer modules.
+- Optionally attaches dependency analysis based on configuration.
+
+Raises:
+
+- `ValueError` when the path is invalid.
+- `TimeoutError` when scan/analysis exceeds configured timeout.
+
+### `StatsvyApi.compare(project1, project2) -> ApiComparisonResult`
+
+Compares two `ApiScanResult` snapshots and returns structured deltas.
+
+### `StatsvyApi.format_result(result, output_format=None, config=None, include_css=None) -> str`
+
+Formats either `ApiScanResult` or `ApiComparisonResult` into output text.
+
+Supported `output_format` values:
+
+- `table`
+- `json`
+- `markdown` / `md`
+- `html`
+
+## Configuration in API Usage
+
+API usage is explicit: pass a `Config` object when you need overrides.
+
+```python
+from dataclasses import replace
+
+from statsvy.api import StatsvyApi
+from statsvy.data.config import Config
+
+config = Config.default()
+config = replace(
+    config,
+    core=replace(config.core, default_format="json", show_progress=False),
+)
+
+result = StatsvyApi.scan(".", config=config)
+print(StatsvyApi.format_result(result, config=config))
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,3 +37,4 @@ statsvy scan . --format json
 - [Quick Start](quickstart.md) — Learn the basics in 5 minutes
 - [CLI Reference](cli-reference.md) — Full command documentation
 - [Configuration](configuration.md) — Customize statsvy to your needs
+- [Developer API](developer-api.md) — Integrate statsvy in Python code

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - Development:
       - Contributing: contributing.md
       - Architecture: architecture.md
+      - Developer API: developer-api.md
   - Changelog: changelog.md
 
 markdown_extensions:

--- a/src/statsvy/__init__.py
+++ b/src/statsvy/__init__.py
@@ -1,3 +1,12 @@
 """Statsvy - Source code metrics and statistics tool."""
 
+from statsvy.api import ApiComparisonResult, ApiScanResult, StatsvyApi
+
 __version__ = "1.0.0"
+
+__all__ = [
+    "ApiComparisonResult",
+    "ApiScanResult",
+    "StatsvyApi",
+    "__version__",
+]

--- a/src/statsvy/api/__init__.py
+++ b/src/statsvy/api/__init__.py
@@ -1,0 +1,11 @@
+"""Public programmatic API for Statsvy.
+
+This module exposes a stable, minimal API surface intended for integrations
+that want to use Statsvy without invoking the CLI.
+"""
+
+from statsvy.api.api_comparison_result import ApiComparisonResult
+from statsvy.api.api_scan_result import ApiScanResult
+from statsvy.api.public_api import StatsvyApi
+
+__all__ = ["ApiComparisonResult", "ApiScanResult", "StatsvyApi"]

--- a/src/statsvy/api/api_comparison_result.py
+++ b/src/statsvy/api/api_comparison_result.py
@@ -1,0 +1,23 @@
+"""Public DTO for comparison results."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from statsvy.api.api_scan_result import ApiScanResult
+
+
+@dataclass(frozen=True, slots=True)
+class ApiComparisonResult:
+    """Represent an API-safe comparison result contract.
+
+    Attributes:
+        project1: The first scan snapshot used for comparison.
+        project2: The second scan snapshot used for comparison.
+        deltas: Calculated delta payload grouped by category.
+        timestamp: ISO-8601 timestamp when comparison completed.
+    """
+
+    project1: ApiScanResult
+    project2: ApiScanResult
+    deltas: dict[str, Any]
+    timestamp: str

--- a/src/statsvy/api/api_mapper.py
+++ b/src/statsvy/api/api_mapper.py
@@ -1,0 +1,179 @@
+"""Mapping utilities between internal models and public API DTOs."""
+
+from datetime import datetime
+from pathlib import Path
+
+from statsvy.api.api_comparison_result import ApiComparisonResult
+from statsvy.api.api_scan_result import ApiScanResult
+from statsvy.data.comparison_result import ComparisonResult
+from statsvy.data.dependency import Dependency
+from statsvy.data.dependency_info import DependencyInfo
+from statsvy.data.metrics import Metrics
+
+
+class ApiMapper:
+    """Maps between internal domain models and public API DTOs."""
+
+    @staticmethod
+    def to_api_scan_result(metrics: Metrics) -> ApiScanResult:
+        """Convert internal ``Metrics`` into ``ApiScanResult``.
+
+        Args:
+            metrics: Internal metrics object.
+
+        Returns:
+            Public API DTO.
+        """
+        dependency_info = metrics.dependencies
+        dependencies: tuple[tuple[str, str, str, str], ...] = ()
+        dependency_total: int | None = None
+        dependency_prod: int | None = None
+        dependency_dev: int | None = None
+        dependency_optional: int | None = None
+        dependency_sources: tuple[str, ...] = ()
+        dependency_conflicts: tuple[str, ...] = ()
+
+        if dependency_info is not None:
+            dependencies = tuple(
+                (
+                    dependency.name,
+                    dependency.version,
+                    dependency.category,
+                    dependency.source_file,
+                )
+                for dependency in dependency_info.dependencies
+            )
+            dependency_total = dependency_info.total_count
+            dependency_prod = dependency_info.prod_count
+            dependency_dev = dependency_info.dev_count
+            dependency_optional = dependency_info.optional_count
+            dependency_sources = dependency_info.sources
+            dependency_conflicts = dependency_info.conflicts
+
+        return ApiScanResult(
+            name=metrics.name,
+            path=str(metrics.path),
+            timestamp=metrics.timestamp.isoformat(),
+            total_files=metrics.total_files,
+            total_size_bytes=metrics.total_size_bytes,
+            total_size_kb=metrics.total_size_kb,
+            total_size_mb=metrics.total_size_mb,
+            total_lines=metrics.total_lines,
+            lines_by_lang=dict(metrics.lines_by_lang),
+            comment_lines_by_lang=dict(metrics.comment_lines_by_lang),
+            blank_lines_by_lang=dict(metrics.blank_lines_by_lang),
+            lines_by_category=dict(metrics.lines_by_category),
+            comment_lines=metrics.comment_lines,
+            blank_lines=metrics.blank_lines,
+            dependency_total=dependency_total,
+            dependency_prod=dependency_prod,
+            dependency_dev=dependency_dev,
+            dependency_optional=dependency_optional,
+            dependency_sources=dependency_sources,
+            dependency_conflicts=dependency_conflicts,
+            dependencies=dependencies,
+        )
+
+    @staticmethod
+    def to_api_comparison_result(comparison: ComparisonResult) -> ApiComparisonResult:
+        """Convert internal ``ComparisonResult`` to ``ApiComparisonResult``.
+
+        Args:
+            comparison: Internal comparison object.
+
+        Returns:
+            Public API DTO.
+        """
+        return ApiComparisonResult(
+            project1=ApiMapper.to_api_scan_result(comparison.project1),
+            project2=ApiMapper.to_api_scan_result(comparison.project2),
+            deltas=dict(comparison.deltas),
+            timestamp=comparison.timestamp.isoformat(),
+        )
+
+    @staticmethod
+    def to_internal_metrics(result: ApiScanResult) -> Metrics:
+        """Convert ``ApiScanResult`` to internal ``Metrics``.
+
+        Args:
+            result: Public API scan DTO.
+
+        Returns:
+            Internal metrics object.
+        """
+        dependency_info = ApiMapper._to_dependency_info(result)
+
+        return Metrics(
+            name=result.name,
+            path=Path(result.path),
+            timestamp=datetime.fromisoformat(result.timestamp),
+            total_files=result.total_files,
+            total_size_bytes=result.total_size_bytes,
+            total_size_kb=result.total_size_kb,
+            total_size_mb=result.total_size_mb,
+            lines_by_lang=dict(result.lines_by_lang),
+            comment_lines_by_lang=dict(result.comment_lines_by_lang),
+            blank_lines_by_lang=dict(result.blank_lines_by_lang),
+            lines_by_category=dict(result.lines_by_category),
+            comment_lines=result.comment_lines,
+            blank_lines=result.blank_lines,
+            total_lines=result.total_lines,
+            dependencies=dependency_info,
+        )
+
+    @staticmethod
+    def to_internal_comparison(result: ApiComparisonResult) -> ComparisonResult:
+        """Convert ``ApiComparisonResult`` to internal ``ComparisonResult``.
+
+        Args:
+            result: Public API comparison DTO.
+
+        Returns:
+            Internal comparison object.
+        """
+        return ComparisonResult(
+            project1=ApiMapper.to_internal_metrics(result.project1),
+            project2=ApiMapper.to_internal_metrics(result.project2),
+            deltas=dict(result.deltas),
+            timestamp=datetime.fromisoformat(result.timestamp),
+        )
+
+    @staticmethod
+    def _to_dependency_info(result: ApiScanResult) -> DependencyInfo | None:
+        """Build internal dependency info from API DTO.
+
+        Args:
+            result: API scan result.
+
+        Returns:
+            DependencyInfo when dependency fields are present, otherwise None.
+        """
+        has_dependency_payload = (
+            result.dependency_total is not None
+            or result.dependency_prod is not None
+            or result.dependency_dev is not None
+            or result.dependency_optional is not None
+            or bool(result.dependencies)
+        )
+        if not has_dependency_payload:
+            return None
+
+        dependencies = tuple(
+            Dependency(
+                name=name,
+                version=version,
+                category=category,
+                source_file=source_file,
+            )
+            for name, version, category, source_file in result.dependencies
+        )
+
+        return DependencyInfo(
+            dependencies=dependencies,
+            prod_count=result.dependency_prod or 0,
+            dev_count=result.dependency_dev or 0,
+            optional_count=result.dependency_optional or 0,
+            total_count=result.dependency_total or len(dependencies),
+            sources=result.dependency_sources,
+            conflicts=result.dependency_conflicts,
+        )

--- a/src/statsvy/api/api_scan_result.py
+++ b/src/statsvy/api/api_scan_result.py
@@ -1,0 +1,59 @@
+"""Public DTO for scan results.
+
+This data structure is part of the programmatic API contract and is intended
+to be stable across patch/minor releases within the same major version.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ApiScanResult:
+    """Represent an API-safe scan result contract.
+
+    Attributes:
+        name: Project or scan run identifier.
+        path: Filesystem path that was analyzed.
+        timestamp: ISO-8601 timestamp when the scan completed.
+        total_files: Number of scanned files.
+        total_size_bytes: Total size in bytes for scanned files.
+        total_size_kb: Total size in kilobytes.
+        total_size_mb: Total size in megabytes.
+        total_lines: Total number of analyzed lines.
+        lines_by_lang: Line counts per language.
+        comment_lines_by_lang: Comment line counts per language.
+        blank_lines_by_lang: Blank line counts per language.
+        lines_by_category: Line counts grouped by category.
+        comment_lines: Total comment lines.
+        blank_lines: Total blank lines.
+        dependency_total: Total number of detected dependencies.
+        dependency_prod: Number of production dependencies.
+        dependency_dev: Number of development dependencies.
+        dependency_optional: Number of optional dependencies.
+        dependency_sources: Source files used for dependency analysis.
+        dependency_conflicts: Reported dependency conflicts.
+        dependencies: Dependency tuples as
+            ``(name, version, category, source_file)``.
+    """
+
+    name: str
+    path: str
+    timestamp: str
+    total_files: int
+    total_size_bytes: int
+    total_size_kb: int
+    total_size_mb: int
+    total_lines: int
+    lines_by_lang: dict[str, int]
+    comment_lines_by_lang: dict[str, int]
+    blank_lines_by_lang: dict[str, int]
+    lines_by_category: dict[str, int]
+    comment_lines: int
+    blank_lines: int
+    dependency_total: int | None = None
+    dependency_prod: int | None = None
+    dependency_dev: int | None = None
+    dependency_optional: int | None = None
+    dependency_sources: tuple[str, ...] = ()
+    dependency_conflicts: tuple[str, ...] = ()
+    dependencies: tuple[tuple[str, str, str, str], ...] = ()

--- a/src/statsvy/api/public_api.py
+++ b/src/statsvy/api/public_api.py
@@ -1,0 +1,161 @@
+"""Public API facade for programmatic Statsvy usage."""
+
+from dataclasses import replace
+from pathlib import Path
+
+from statsvy.api.api_comparison_result import ApiComparisonResult
+from statsvy.api.api_mapper import ApiMapper
+from statsvy.api.api_scan_result import ApiScanResult
+from statsvy.core.analyzer import Analyzer
+from statsvy.core.comparison import ComparisonAnalyzer
+from statsvy.core.formatter import Formatter
+from statsvy.core.git_stats import GitStats
+from statsvy.core.project_scanner import ProjectScanner
+from statsvy.core.scanner import Scanner
+from statsvy.data.config import Config
+from statsvy.data.metrics import Metrics
+from statsvy.utils.timeout_checker import TimeoutChecker
+
+
+class StatsvyApi:
+    """Class-based public API facade for Statsvy integrations."""
+
+    @staticmethod
+    def scan(path: str | Path, config: Config | None = None) -> ApiScanResult:
+        """Scan and analyze a directory.
+
+        Args:
+            path: Target directory to scan.
+            config: Optional configuration overrides.
+
+        Returns:
+            API DTO containing scan and analysis metrics.
+
+        Raises:
+            ValueError: If ``path`` does not exist or is not a directory.
+            TimeoutError: If scan or analysis exceeds configured timeout.
+        """
+        effective_config = config or Config.default()
+        target_path = Path(path)
+        timeout_checker = TimeoutChecker(effective_config.scan.timeout_seconds)
+        timeout_checker.start()
+
+        scanner = Scanner(
+            target_path,
+            ignore=effective_config.scan.ignore_patterns,
+            no_gitignore=not effective_config.scan.respect_gitignore,
+            config=effective_config,
+        )
+        scan_result = scanner.scan(timeout_checker)
+
+        analyzer = Analyzer(
+            name=f"{Path.cwd()}/{target_path.name}",
+            path=target_path,
+            language_map_path=StatsvyApi._language_config_path(),
+            custom_language_mapping=effective_config.language.custom_language_mapping,
+            config=effective_config,
+        )
+        metrics = analyzer.analyze(scan_result, timeout_checker)
+        metrics_with_dependencies = StatsvyApi._attach_dependencies(
+            metrics, target_path, effective_config
+        )
+        return ApiMapper.to_api_scan_result(metrics_with_dependencies)
+
+    @staticmethod
+    def compare(
+        project1: ApiScanResult,
+        project2: ApiScanResult,
+    ) -> ApiComparisonResult:
+        """Compare two API scan snapshots.
+
+        Args:
+            project1: First project scan result.
+            project2: Second project scan result.
+
+        Returns:
+            API DTO containing computed deltas.
+        """
+        project1_metrics = ApiMapper.to_internal_metrics(project1)
+        project2_metrics = ApiMapper.to_internal_metrics(project2)
+        comparison = ComparisonAnalyzer.compare(project1_metrics, project2_metrics)
+        return ApiMapper.to_api_comparison_result(comparison)
+
+    @staticmethod
+    def format_result(
+        result: ApiScanResult | ApiComparisonResult,
+        output_format: str | None = None,
+        config: Config | None = None,
+        include_css: bool | None = None,
+    ) -> str:
+        """Format API DTO results into text output.
+
+        Args:
+            result: API scan or comparison DTO to format.
+            output_format: Output format (``table``, ``json``, ``markdown``,
+                ``md``, ``html``). Uses config default when omitted.
+            config: Optional configuration controlling formatter behavior.
+            include_css: When using HTML, controls embedded CSS output.
+
+        Returns:
+            Formatted output text.
+
+        Raises:
+            ValueError: If output format is unknown.
+        """
+        effective_config = config or Config.default()
+        selected_format = output_format or effective_config.core.default_format
+
+        if isinstance(result, ApiComparisonResult):
+            internal_comparison = ApiMapper.to_internal_comparison(result)
+            return Formatter.format(
+                internal_comparison,
+                selected_format,
+                display_config=effective_config.display,
+                include_css=include_css,
+            )
+
+        internal_metrics = ApiMapper.to_internal_metrics(result)
+        git_info = (
+            GitStats.detect_repository(internal_metrics.path, effective_config)
+            if effective_config.git.enabled
+            else None
+        )
+        return Formatter.format(
+            internal_metrics,
+            selected_format,
+            git_info=git_info,
+            display_config=effective_config.display,
+            git_config=effective_config.git,
+            include_css=include_css,
+        )
+
+    @staticmethod
+    def _language_config_path() -> Path:
+        """Return path to built-in language mapping asset."""
+        package_dir = Path(__file__).resolve().parent.parent.parent.parent
+        return package_dir / "assets" / "languages.yml"
+
+    @staticmethod
+    def _attach_dependencies(
+        metrics: Metrics,
+        target_path: Path,
+        config: Config,
+    ) -> Metrics:
+        """Attach dependency analysis data when enabled.
+
+        Dependency analysis failures are treated as non-fatal and the original
+        metrics are returned unchanged.
+        """
+        if not config.dependencies.include_dependencies:
+            return metrics
+
+        project_scanner = ProjectScanner(target_path)
+        try:
+            project_info = project_scanner.scan()
+        except ValueError:
+            return metrics
+
+        if project_info is None or project_info.dependencies is None:
+            return metrics
+
+        return replace(metrics, dependencies=project_info.dependencies)

--- a/tests/api/test_public_api.py
+++ b/tests/api/test_public_api.py
@@ -1,0 +1,292 @@
+"""Contract tests for the public programmatic API."""
+
+import datetime
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from statsvy.api import ApiComparisonResult, ApiScanResult, StatsvyApi
+from statsvy.core.analyzer import Analyzer
+from statsvy.core.comparison import ComparisonAnalyzer
+from statsvy.core.formatter import Formatter
+from statsvy.core.scanner import Scanner
+from statsvy.data.config import Config
+from statsvy.data.metrics import Metrics
+from statsvy.data.scan_result import ScanResult
+
+
+def test_scan_returns_api_scan_result(tmp_path: Path) -> None:
+    """Scan should return the public API DTO with expected core fields."""
+    project_dir = tmp_path / "sample"
+    project_dir.mkdir()
+    (project_dir / "main.py").write_text("print('hello')\n", encoding="utf-8")
+
+    scan_result = StatsvyApi.scan(project_dir)
+
+    assert isinstance(scan_result, ApiScanResult)
+    assert scan_result.total_files >= 1
+    assert scan_result.path == str(project_dir)
+    assert isinstance(scan_result.lines_by_lang, dict)
+
+
+def test_compare_returns_api_comparison_result(tmp_path: Path) -> None:
+    """Compare should return public comparison DTO with deltas."""
+    project_a = tmp_path / "project_a"
+    project_b = tmp_path / "project_b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    (project_a / "app.py").write_text("print('a')\n", encoding="utf-8")
+    (project_b / "app.py").write_text("print('b')\nprint('c')\n", encoding="utf-8")
+
+    result_a = StatsvyApi.scan(project_a)
+    result_b = StatsvyApi.scan(project_b)
+    comparison = StatsvyApi.compare(result_a, result_b)
+
+    assert isinstance(comparison, ApiComparisonResult)
+    assert "overall" in comparison.deltas
+
+
+def test_format_result_json_for_scan(tmp_path: Path) -> None:
+    """Formatting scan result as JSON should return a JSON payload."""
+    project_dir = tmp_path / "json_scan"
+    project_dir.mkdir()
+    (project_dir / "script.py").write_text("print('x')\n", encoding="utf-8")
+
+    result = StatsvyApi.scan(project_dir)
+    output = StatsvyApi.format_result(result, output_format="json")
+
+    assert output.strip().startswith("{")
+    assert '"total_files"' in output
+
+
+def test_format_result_json_for_comparison(tmp_path: Path) -> None:
+    """Formatting comparison result as JSON should include comparison key."""
+    project_a = tmp_path / "fmt_a"
+    project_b = tmp_path / "fmt_b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    (project_a / "alpha.py").write_text("x = 1\n", encoding="utf-8")
+    (project_b / "beta.py").write_text("x = 1\ny = 2\n", encoding="utf-8")
+
+    comparison = StatsvyApi.compare(
+        StatsvyApi.scan(project_a),
+        StatsvyApi.scan(project_b),
+    )
+    output = StatsvyApi.format_result(comparison, output_format="json")
+
+    assert output.strip().startswith("{")
+    assert '"comparison"' in output
+
+
+def test_format_result_respects_config_default_format(tmp_path: Path) -> None:
+    """Formatter should default to config.core.default_format when omitted."""
+    project_dir = tmp_path / "default_format"
+    project_dir.mkdir()
+    (project_dir / "code.py").write_text("print('ok')\n", encoding="utf-8")
+
+    config = Config.default()
+    config = config.__class__(
+        core=config.core.__class__(
+            name=config.core.name,
+            path=config.core.path,
+            default_format="json",
+            out_dir=config.core.out_dir,
+            verbose=config.core.verbose,
+            color=config.core.color,
+            show_progress=False,
+            performance=config.core.performance,
+        ),
+        scan=config.scan,
+        language=config.language,
+        storage=config.storage,
+        git=config.git,
+        display=config.display,
+        comparison=config.comparison,
+        dependencies=config.dependencies,
+        files=config.files,
+    )
+
+    result = StatsvyApi.scan(project_dir, config=config)
+    output = StatsvyApi.format_result(result, config=config)
+
+    assert output.strip().startswith("{")
+
+
+def test_scan_delegates_to_internal_scanner_and_analyzer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Public scan API should delegate to core Scanner and Analyzer."""
+    project_dir = tmp_path / "wired"
+    project_dir.mkdir()
+
+    calls = {
+        "scanner_scan": 0,
+        "analyzer_analyze": 0,
+    }
+
+    def fake_scanner_scan(
+        _self: object,
+        _timeout_checker: object | None = None,
+    ) -> ScanResult:
+        calls["scanner_scan"] += 1
+        return ScanResult(
+            total_files=1,
+            total_size_bytes=10,
+            scanned_files=(project_dir / "sample.py",),
+        )
+
+    def fake_analyzer_analyze(
+        _self: object,
+        scan_result: ScanResult,
+        _timeout_checker: object | None = None,
+    ) -> Metrics:
+        calls["analyzer_analyze"] += 1
+        return Metrics(
+            name="api-test",
+            path=project_dir,
+            timestamp=datetime.datetime.now(),
+            total_files=scan_result.total_files,
+            total_size_bytes=scan_result.total_size_bytes,
+            total_size_kb=0,
+            total_size_mb=0,
+            lines_by_lang={"python": 1},
+            comment_lines_by_lang={"python": 0},
+            blank_lines_by_lang={"python": 0},
+            lines_by_category={"code": 1, "comment": 0, "blank": 0},
+            comment_lines=0,
+            blank_lines=0,
+            total_lines=1,
+            dependencies=None,
+        )
+
+    def fake_project_scan(_self: object) -> None:
+        return None
+
+    monkeypatch.setattr("statsvy.core.scanner.Scanner.scan", fake_scanner_scan)
+    monkeypatch.setattr("statsvy.core.analyzer.Analyzer.analyze", fake_analyzer_analyze)
+    monkeypatch.setattr(
+        "statsvy.core.project_scanner.ProjectScanner.scan",
+        fake_project_scan,
+    )
+
+    result = StatsvyApi.scan(project_dir)
+
+    assert isinstance(result, ApiScanResult)
+    assert result.name == "api-test"
+    assert calls["scanner_scan"] == 1
+    assert calls["analyzer_analyze"] == 1
+
+
+def test_scan_matches_internal_pipeline_contract(tmp_path: Path) -> None:
+    """API scan should match results from direct internal scan/analyze flow."""
+    project_dir = tmp_path / "parity"
+    project_dir.mkdir()
+    (project_dir / "main.py").write_text("print('hello')\n", encoding="utf-8")
+    (project_dir / "utils.py").write_text("x = 1\n", encoding="utf-8")
+
+    config = Config.default()
+    config = replace(
+        config,
+        core=replace(config.core, show_progress=False),
+        dependencies=replace(config.dependencies, include_dependencies=False),
+    )
+
+    api_result = StatsvyApi.scan(project_dir, config=config)
+
+    scanner = Scanner(
+        project_dir,
+        ignore=config.scan.ignore_patterns,
+        no_gitignore=not config.scan.respect_gitignore,
+        config=config,
+    )
+    scan_result = scanner.scan()
+    analyzer = Analyzer(
+        name=f"{Path.cwd()}/{project_dir.name}",
+        path=project_dir,
+        language_map_path=StatsvyApi._language_config_path(),
+        custom_language_mapping=config.language.custom_language_mapping,
+        config=config,
+    )
+    internal_metrics = analyzer.analyze(scan_result)
+
+    assert api_result.total_files == internal_metrics.total_files
+    assert api_result.total_size_bytes == internal_metrics.total_size_bytes
+    assert api_result.total_lines == internal_metrics.total_lines
+    assert api_result.lines_by_lang == dict(internal_metrics.lines_by_lang)
+    assert api_result.comment_lines_by_lang == dict(
+        internal_metrics.comment_lines_by_lang
+    )
+    assert api_result.blank_lines_by_lang == dict(internal_metrics.blank_lines_by_lang)
+
+
+def test_compare_and_format_match_internal_modules(tmp_path: Path) -> None:
+    """API compare/format should stay aligned with internal comparison formatter."""
+    project_a = tmp_path / "internal_a"
+    project_b = tmp_path / "internal_b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    (project_a / "app.py").write_text("a = 1\n", encoding="utf-8")
+    (project_b / "app.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+
+    config = Config.default()
+    config = replace(
+        config,
+        core=replace(config.core, show_progress=False),
+        dependencies=replace(config.dependencies, include_dependencies=False),
+        git=replace(config.git, enabled=False),
+    )
+
+    api_a = StatsvyApi.scan(project_a, config=config)
+    api_b = StatsvyApi.scan(project_b, config=config)
+    api_comparison = StatsvyApi.compare(api_a, api_b)
+
+    scanner_a = Scanner(
+        project_a,
+        ignore=config.scan.ignore_patterns,
+        no_gitignore=not config.scan.respect_gitignore,
+        config=config,
+    )
+    scanner_b = Scanner(
+        project_b,
+        ignore=config.scan.ignore_patterns,
+        no_gitignore=not config.scan.respect_gitignore,
+        config=config,
+    )
+    analyzer_a = Analyzer(
+        name=f"{Path.cwd()}/{project_a.name}",
+        path=project_a,
+        language_map_path=StatsvyApi._language_config_path(),
+        custom_language_mapping=config.language.custom_language_mapping,
+        config=config,
+    )
+    analyzer_b = Analyzer(
+        name=f"{Path.cwd()}/{project_b.name}",
+        path=project_b,
+        language_map_path=StatsvyApi._language_config_path(),
+        custom_language_mapping=config.language.custom_language_mapping,
+        config=config,
+    )
+
+    metrics_a = analyzer_a.analyze(scanner_a.scan())
+    metrics_b = analyzer_b.analyze(scanner_b.scan())
+    internal_comparison = ComparisonAnalyzer.compare(metrics_a, metrics_b)
+
+    assert api_comparison.deltas == internal_comparison.deltas
+
+    api_json = StatsvyApi.format_result(
+        api_comparison,
+        output_format="json",
+        config=config,
+    )
+    internal_json = Formatter.format(
+        internal_comparison,
+        "json",
+        display_config=config.display,
+        include_css=None,
+    )
+    assert api_json == internal_json


### PR DESCRIPTION
## Description
Added public API to programmatically invoke Statsvy without using the CLI.

## Changes
- add a class-based public API under `src/statsvy/api` via `StatsvyApi`
- add stable API DTOs (`ApiScanResult`, `ApiComparisonResult`) and internal mapping layer
- expose API symbols from package root
- add API contract and parity tests in `tests/api/test_public_api.py`
- add developer-focused API docs and wire into MkDocs navigation
- API entrypoint: `StatsvyApi.scan`, `StatsvyApi.compare`, `StatsvyApi.format_result`
- No free-function API surface in the new module; all public operations live on classes
- Added wiring/parity tests so API behavior stays aligned with relevant internal modules

## Validation
- pre-commit hooks passed on commit (ruff-format, ruff, yaml checks)
- API tests pass locally:
  - `python -m pytest tests/api/test_public_api.py -q --no-cov`
- docs build in strict mode passes:
  - `uv run mkdocs build --strict`
