### PR TITLE
fix: correct single-core CPU tracking for --track-cpu

### DIFF
--- a/src/statsvy/data/performance_metrics.py
+++ b/src/statsvy/data/performance_metrics.py
@@ -22,11 +22,12 @@ class PerformanceMetrics:
         cpu_seconds: Total process CPU time delta (user + system).
         cpu_user_seconds: Process user CPU time delta.
         cpu_system_seconds: Process system CPU time delta.
-        cpu_percent_single_core: CPU usage normalized to one core.
-            Formula: cpu_seconds / wall_seconds * 100.
-            Can exceed 100% when multiple cores are actively used.
-        cpu_percent_all_cores: CPU usage normalized by logical core count.
-            Formula: cpu_percent_single_core / cpu_count.
+        cpu_percent_single_core: CPU usage for the current thread normalized
+            to one core. Formula: thread_cpu_seconds / wall_seconds * 100,
+            then clamped to 0..100.
+        cpu_percent_all_cores: Process CPU usage normalized by logical core
+            count. Formula: (cpu_seconds / wall_seconds * 100) / cpu_count,
+            then clamped to 0..100.
     """
 
     peak_memory_bytes: int


### PR DESCRIPTION
## Description

Fixes incorrect CPU normalization semantics for `CPU% (single-core)` when `--track-cpu` is enabled. The metric now uses current-thread CPU time over wall time (bounded to `0..100`) instead of process-wide CPU time, which could exceed 100% in practice.

## Changes

- Use `time.thread_time()` for single-core CPU% calculation in `PerformanceTracker`
- Keep process CPU deltas for total CPU seconds and derive all-cores CPU% from process CPU / core count
- Add regression tests covering thread-based normalization and >100% clamp behavior
- Update `PerformanceMetrics` docstring to reflect corrected metric semantics

## Related Issues

Closes #25